### PR TITLE
Replace dots with dashes for pipeline detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ async function triggerPullRequestCI(repoName, prNumber, commit) {
   const affected_files = prFilenames.join(':');
   log.info(`files affected by this PR: ${affected_files}`);
 
-  const pipelineName = path.basename(repoName);
+  const pipelineName = path.basename(repoName).replace(/\./g, '-');
 
   const pipeline = await buildkiteOrg.getPipelineAsync(pipelineName);
 


### PR DESCRIPTION
Buildkite doesn't allow you to have dots in the pipeline ID, so we should replace any with dashes.