### PR TITLE
Link Buildkite builds to Github PR

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+/node_modules/
+npm-debug.log
+public_html/terminal.css

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:9-alpine
+
+ADD . /src
+WORKDIR /src
+RUN npm install
+
+ENTRYPOINT [ "npm" ]
+CMD [ "run", "start" ]

--- a/index.js
+++ b/index.js
@@ -469,14 +469,18 @@ async function onGithubPullRequest(payload) {
     }
     break;
   }
+  case 'edited':
   case 'labeled':
+  {
+    const [hasLabel, inWhitelist] = await Promise.all([prHasLabel(repoName, prNumber, CI_LABEL), userInCiWhitelist(repoName, user)]);
     if (!merged) {
-      if (await prHasLabel(repoName, prNumber, CI_LABEL)) {
+      if (hasLabel || inWhitelist) {
         await triggerPullRequestCI(repoName, prNumber, pull_request);
       }
       await autoMergePullRequest(repoName, prNumber);
     }
     break;
+  }
   default:
     log.info('Ignored pull request action:', payload.action);
   }


### PR DESCRIPTION
The Buildkite API can more tightly integrate with Github PR's if passing
some specific metadata. This borrows concepts from the M3 PR bash script
(https://git.io/fjDhx) that we use to manually trigger CI builds. Tested
locally.

I still have to test this with an external contributor's account.

Example difference in builds:
![image](https://user-images.githubusercontent.com/434973/61892111-1b42a700-aed9-11e9-8662-a31520a9e765.png)