### PR TITLE
Ignore PR `edited` event

### DIFF
--- a/index.js
+++ b/index.js
@@ -469,7 +469,6 @@ async function onGithubPullRequest(payload) {
     }
     break;
   }
-  case 'edited':
   case 'labeled':
   {
     const [hasLabel, inWhitelist] = await Promise.all([prHasLabel(repoName, prNumber, CI_LABEL), userInCiWhitelist(repoName, user)]);


### PR DESCRIPTION
Currently, a new CI run is triggered if the title/body of a pull request is edited, which isn't necessary and just causes extra worker usage. This PR updates it to ignore this event